### PR TITLE
Feature/optional tz ampm indicators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Worktrees
+.worktrees/
+
 # Development files
 node_modules/
 .cache/

--- a/package.json
+++ b/package.json
@@ -47,7 +47,9 @@
       "SETTING_TEMP_UNIT",
       "SETTING_DATE_FORMAT",
       "SETTING_ACCENT_COLOR",
-      "SETTING_BATTERY_DISPLAY"
+      "SETTING_BATTERY_DISPLAY",
+      "SETTING_SHOW_TIMEZONE",
+      "SETTING_SHOW_AMPM"
     ],
     "resources": {
       "media": [

--- a/src/c/modules/settings.c
+++ b/src/c/modules/settings.c
@@ -18,6 +18,8 @@ static const Settings s_defaults = {
     .date_format = "%A, %m/%d",
     .accent_color = {.argb = 0b11111111}, // GColorWhite
     .battery_display = BATTERY_DISPLAY_ICON,
+    .show_timezone = true,
+    .show_ampm = true,
 };
 
 void settings_init(void) {
@@ -61,6 +63,14 @@ void settings_apply_from_message(DictionaryIterator *iter) {
 			s_settings.battery_display = (BatteryDisplay)bd;
 		}
 	}
+
+	t = dict_find(iter, MESSAGE_KEY_SETTING_SHOW_TIMEZONE);
+	if (t)
+		s_settings.show_timezone = (t->value->int8 != 0);
+
+	t = dict_find(iter, MESSAGE_KEY_SETTING_SHOW_AMPM);
+	if (t)
+		s_settings.show_ampm = (t->value->int8 != 0);
 
 	settings_save();
 }

--- a/src/c/modules/settings.c
+++ b/src/c/modules/settings.c
@@ -13,6 +13,8 @@
 
 static Settings s_settings;
 
+// Default settings values. New fields must be appended to the end of the
+// struct to maintain compatibility with old persisted data.
 static const Settings s_defaults = {
     .temp_unit_celsius = true,
     .date_format = "%A, %m/%d",
@@ -24,10 +26,14 @@ static const Settings s_defaults = {
 
 void settings_init(void) {
 	s_settings = s_defaults;
-	if (persist_exists(STORAGE_KEY_SETTINGS) &&
-	    persist_get_size(STORAGE_KEY_SETTINGS) == (int)sizeof(s_settings)) {
-		persist_read_data(STORAGE_KEY_SETTINGS, &s_settings,
-		                  sizeof(s_settings));
+	if (persist_exists(STORAGE_KEY_SETTINGS)) {
+		int stored_size = persist_get_size(STORAGE_KEY_SETTINGS);
+		// Read however many bytes were persisted, as long as they fit within
+		// the current struct. New fields appended to the end will retain their
+		// default values; old fields are restored from storage.
+		if (stored_size > 0 && stored_size <= (int)sizeof(s_settings)) {
+			persist_read_data(STORAGE_KEY_SETTINGS, &s_settings, stored_size);
+		}
 	}
 }
 

--- a/src/c/modules/settings.c
+++ b/src/c/modules/settings.c
@@ -28,11 +28,15 @@ void settings_init(void) {
 	s_settings = s_defaults;
 	if (persist_exists(STORAGE_KEY_SETTINGS)) {
 		int stored_size = persist_get_size(STORAGE_KEY_SETTINGS);
-		// Read however many bytes were persisted, as long as they fit within
-		// the current struct. New fields appended to the end will retain their
-		// default values; old fields are restored from storage.
-		if (stored_size > 0 && stored_size <= (int)sizeof(s_settings)) {
-			persist_read_data(STORAGE_KEY_SETTINGS, &s_settings, stored_size);
+		// Read min(stored, current) bytes so field migration works in both
+		// directions: upgrading (stored < current) keeps new field defaults;
+		// downgrading (stored > current) discards unknown trailing fields but
+		// preserves all fields the current version does know about.
+		if (stored_size > 0) {
+			int read_size = stored_size < (int)sizeof(s_settings)
+			                    ? stored_size
+			                    : (int)sizeof(s_settings);
+			persist_read_data(STORAGE_KEY_SETTINGS, &s_settings, read_size);
 		}
 	}
 }

--- a/src/c/modules/settings.h
+++ b/src/c/modules/settings.h
@@ -20,6 +20,8 @@ typedef struct {
 	char date_format[32];
 	GColor accent_color;
 	BatteryDisplay battery_display;
+	bool show_timezone;
+	bool show_ampm;
 } Settings;
 
 void settings_init(void);

--- a/src/c/ui/time_layer.c
+++ b/src/c/ui/time_layer.c
@@ -177,6 +177,8 @@ void time_layer_update(TimeLayer *layer, struct tm *tick_time,
 	}
 	text_layer_set_text(layer->time_label, layer->time_buf);
 	text_layer_set_text(layer->ampm_label, layer->ampm_buf);
+	layer_set_hidden(text_layer_get_layer(layer->ampm_label),
+	                 !settings->show_ampm);
 
 	// Timezone abbreviation — use manual override if set (e.g. demo mode),
 	// otherwise derive from strftime and hide numeric offsets or empty values.
@@ -188,6 +190,8 @@ void time_layer_update(TimeLayer *layer, struct tm *tick_time,
 		                (layer->tz_buf[1] >= 'A' && layer->tz_buf[1] <= 'Z');
 		text_layer_set_text(layer->tz_label, tz_valid ? layer->tz_buf : "");
 	}
+	layer_set_hidden(text_layer_get_layer(layer->tz_label),
+	                 !settings->show_timezone);
 
 	// Date — format string stored in settings; leading zeros stripped
 	// automatically.

--- a/src/pkjs/config.js
+++ b/src/pkjs/config.js
@@ -75,6 +75,20 @@ module.exports = [
 					{ 'label': 'Percentage', 'value': 1 },
 				],
 			},
+			{
+				'type': 'toggle',
+				'messageKey': 'SETTING_SHOW_TIMEZONE',
+				'label': 'Show Timezone',
+				'description': 'Show the timezone abbreviation to the left of the time.',
+				'defaultValue': true,
+			},
+			{
+				'type': 'toggle',
+				'messageKey': 'SETTING_SHOW_AMPM',
+				'label': 'Show AM/PM / 24h Indicator',
+				'description': 'Show the AM/PM or 24h indicator to the right of the time.',
+				'defaultValue': true,
+			},
 		],
 	},
 	{

--- a/src/pkjs/index.js
+++ b/src/pkjs/index.js
@@ -423,6 +423,24 @@ Pebble.addEventListener('webviewclosed', function(e) {
 		return parseInt(v, 10);
 	}
 
+	/**
+	 * Extract a boolean toggle from a raw Clay setting value as 1/0.
+	 * With convert=false, Clay wraps toggle values in an object
+	 * ({value:false}); the object itself is always truthy, so we must
+	 * unwrap .value before testing it. Returns null if the setting is absent.
+	 *
+	 * @param   {boolean|string|{value:boolean}} setting
+	 * @returns {number|null}  1 (on), 0 (off), or null if unset.
+	 */
+	function extractBool(setting) {
+		if (setting === null || setting === undefined) return null;
+		var v = (typeof setting === 'object' && 'value' in setting)
+			? setting.value : setting;
+		// Guard against the string "false", which is truthy in JS.
+		if (v === 'false' || v === '0') return 0;
+		return v ? 1 : 0;
+	}
+
 	var tempUnit = extractInt(rawSettings['SETTING_TEMP_UNIT']);
 	if (isNaN(tempUnit) || tempUnit < 0) {
 		tempUnit = shouldUseFahrenheit() ? 1 : 0;
@@ -441,6 +459,12 @@ Pebble.addEventListener('webviewclosed', function(e) {
 
 	var batteryDisplay = extractInt(rawSettings['SETTING_BATTERY_DISPLAY']);
 	if (!isNaN(batteryDisplay)) dict['SETTING_BATTERY_DISPLAY'] = batteryDisplay;
+
+	var showTimezone = extractBool(rawSettings['SETTING_SHOW_TIMEZONE']);
+	if (showTimezone !== null) dict['SETTING_SHOW_TIMEZONE'] = showTimezone;
+
+	var showAmpm = extractBool(rawSettings['SETTING_SHOW_AMPM']);
+	if (showAmpm !== null) dict['SETTING_SHOW_AMPM'] = showAmpm;
 
 	Pebble.sendAppMessage(dict,
 		function() { console.log('Carbon: settings sent to watch'); },


### PR DESCRIPTION
I really like this watchface ♥️ 

However, I would like to make it a bit more configurable. This is my first contribution (if you want it), allowing to toggle the timezone and AM/PM indicators on the watchface. Something I personally think just clutters the watchface and doesn't bring me any value. So I like to be able to remove it.

I also added some information to AGENTS.md to help my agents run tests and emulators successfully. I'm happy to remove it if you don't want it (or create a separate PR for it).

This is my first small contribution. I do have at least one other thing I'd like to contribute, if you are open to more (localization, other weather sources).