### PR TITLE
Feature/system language support (date)

### DIFF
--- a/src/c/main.c
+++ b/src/c/main.c
@@ -392,6 +392,7 @@ static void prv_window_unload(Window *window) {
 //
 
 static void init(void) {
+	setlocale(LC_ALL, ""); // Use watch system locale for date formatting
 	settings_init();
 
 	// Restore persisted weather before anything renders


### PR DESCRIPTION
Use watch system locale for date formatting.

Only supports languages built-in to the watch settings, additional language packs are not yet supported.

This is a stopgap effort branched off from #11.