### PR TITLE
Feature/debug info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ build/
 screenshots/
 .lock-*
 __pycache__/
+.buildinfo.json
 
 # OS files
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -50,6 +50,27 @@ There are several other weather-focused Pebble watchfaces that might look simila
 
 ---
 
+## Reporting Issues
+
+You may choose to report an issue either through the "contact developer" link in the Pebble app store or by opening a new issue on the project's GitHub repository.
+
+If you're experiencing unexpected behavior, the **Debug** section at the bottom of the settings page can help identify the cause and gives us a snapshot of everything the watchface knows at that moment. Ideally, bug reports should include this debug information to assist in troubleshooting.
+
+To access it:
+1. Open the Pebble app and tap the gear icon next to Carbon to open settings.
+2. Scroll to the bottom of the settings page and expand the **Debug** section.
+3. Review the data inline, or tap **Copy debug info to clipboard** to grab it all as JSON.
+
+The clipboard JSON contains everything displayed in the **Debug** section, including:
+- `activeWatchInfo` — watch hardware, platform, and firmware version
+- `buildInfo` — build metadata including version, git commit hash, branch, dirty flag, and build date
+- `cache` — the full weather payload including fetch time, expiry, and all hourly data
+- `settings` — current Clay settings stored on the phone
+
+> **Before sharing debug info in a GitHub issue, obfuscate the `lat` and `lon` values** inside `cache.payload` and anything else you deem sensitive to protect your location privacy.
+
+---
+
 ## Development
 
 ### Prerequisites
@@ -119,7 +140,23 @@ DEMO=1 pebble build && pebble screenshot --all-platforms
 
 Note: you may need to run `pebble wipe` if the emulator stalls and try again.
 
-### Project Structure
+### Debug Info
+
+The settings page includes a **Debug** section (collapsed by default) powered by the `debug-info` custom Clay component in `src/pkjs/config/debug.js`. It reads the weather cache and current Clay settings from `localStorage` at the moment the settings page is opened, merges in the active watch info from the Clay runtime, and renders each key as a collapsible `<details>` block.
+
+Build metadata is written to `.buildinfo.json` (gitignored) at the start of every `pebble build` and bundled into the JS. It contains:
+
+```json
+{
+  "version": "1.4.0",
+  "hash": "abc1234",
+  "branch": "main",
+  "dirty": false,
+  "buildDate": "2026-07-03T15:00:00+00:00"
+}
+```
+
+To add new fields to the debug output, add keys to the object returned by `formatDebugInfo()` in `src/pkjs/index.js`. The component renders any key it receives without needing changes.
 
 ```
 resources/      # Static assets (e.g. icon font)

--- a/README.md
+++ b/README.md
@@ -140,6 +140,21 @@ DEMO=1 pebble build && pebble screenshot --all-platforms
 
 Note: you may need to run `pebble wipe` if the emulator stalls and try again.
 
+### Project Structure
+
+```
+resources/      # Static assets (e.g. icon font)
+scripts/        # Utility scripts (e.g. icon generation)
+src/
+  c/            # C code
+    generated/  # Generated C code (e.g. from generated icons)
+    modules/    # C modules (settings, weather, etc.)
+    ui/         # Custom UI widget implementations (e.g. graph, event layer)
+    main.c      # C entrypoint
+  pkjs/
+    index.js    # Phone-side weather & location data fetching
+```
+
 ### Debug Info
 
 The settings page includes a **Debug** section (collapsed by default) powered by the `debug-info` custom Clay component in `src/pkjs/config/debug.js`. It reads the weather cache and current Clay settings from `localStorage` at the moment the settings page is opened, merges in the active watch info from the Clay runtime, and renders each key as a collapsible `<details>` block.
@@ -157,19 +172,6 @@ Build metadata is written to `.buildinfo.json` (gitignored) at the start of ever
 ```
 
 To add new fields to the debug output, add keys to the object returned by `formatDebugInfo()` in `src/pkjs/index.js`. The component renders any key it receives without needing changes.
-
-```
-resources/      # Static assets (e.g. icon font)
-scripts/        # Utility scripts (e.g. icon generation)
-src/
-  c/            # C code
-    generated/  # Generated C code (e.g. from generated icons)
-    modules/    # C modules (settings, weather, etc.)
-    ui/         # Custom UI widget implementations (e.g. graph, event layer)
-    main.c      # C entrypoint
-  pkjs/
-    index.js    # Phone-side weather & location data fetching
-```
 
 ### Icons
 

--- a/src/pkjs/config.js
+++ b/src/pkjs/config.js
@@ -7,7 +7,7 @@
  * @link      https://cr0ybot.com/project/pebble-watchface-carbon
  */
 
-const { version } = require("../../package.json");
+const { version } = require('../../package.json');
 
 module.exports = [
 	{
@@ -32,9 +32,9 @@ module.exports = [
 				'description': '"Auto" detects your locale (US = °F, everywhere else = °C).',
 				'defaultValue': -1,
 				'options': [
-					{ 'label': 'Auto (locale)', 'value': -1 },
-					{ 'label': 'Celsius (°C)',  'value': 0  },
-					{ 'label': 'Fahrenheit (°F)', 'value': 1 },
+					{ 'label': 'Auto (locale)',   'value': -1 },
+					{ 'label': 'Celsius (°C)',    'value': 0  },
+					{ 'label': 'Fahrenheit (°F)', 'value': 1  },
 				],
 			},
 		],
@@ -94,5 +94,8 @@ module.exports = [
 	{
 		'type': 'submit',
 		'defaultValue': 'Save Settings',
+	},
+	{
+		'type': 'debug-info',
 	},
 ];

--- a/src/pkjs/config.js
+++ b/src/pkjs/config.js
@@ -7,7 +7,7 @@
  * @link      https://cr0ybot.com/project/pebble-watchface-carbon
  */
 
-const { version } = require('../../package.json');
+const { version, hash } = require('../../.buildinfo.json');
 
 module.exports = [
 	{
@@ -16,7 +16,7 @@ module.exports = [
 	},
 	{
 		'type': 'text',
-		'defaultValue': `v${version}`,
+		'defaultValue': `v${version} (${hash})`,
 	},
 	{
 		'type': 'section',

--- a/src/pkjs/config/debug.js
+++ b/src/pkjs/config/debug.js
@@ -19,6 +19,7 @@ module.exports = {
 		'    <summary class="component component-heading carbon-debug__summary tap-highlight"><h4>Debug</h4></summary>',
 		'    <div class="component component-debug-info carbon-debug__details">',
 		'      <div class="carbon-debug__contents" data-manipulator-target></div>',
+		'      <p class="carbon-debug__disclaimer">Do not share this information publicly without obfuscating sensitive data, such as latitude and longitude.</p>',
 		'      <button type="button" class="carbon-debug__copy">Copy debug info to clipboard</button>',
 		'    </div>',
 		'  </details>',
@@ -28,7 +29,8 @@ module.exports = {
 	style: [
 		'.carbon-debug h4 { display: inline-block; }',
 		'.carbon-debug code { display: block; font-family: monospace; background: #414141; padding: 4px; }',
-		'.carbon-debug__copy { margin: 1rem 0 0; }'
+		'.carbon-debug__disclaimer { margin: 0.7rem 0; font-style: italic; }',
+		'.carbon-debug__copy { margin: 0; }',
 	].join(' '),
 
 	manipulator: 'html',

--- a/src/pkjs/config/debug.js
+++ b/src/pkjs/config/debug.js
@@ -1,0 +1,67 @@
+/**
+ * Clay custom component: debug-info
+ *
+ * Displays cached weather/location debug data in a collapsed <details> panel.
+ * Content is injected at showConfiguration time via clay.meta.userData so
+ * it always reflects the most recent cache snapshot.
+ *
+ * @author    Cory Hughart <cory@coryhughart.com>
+ * @copyright 2026 Cory Hughart
+ * @license   https://www.gnu.org/licenses/gpl-3.0.html GPL-3.0-or-later
+ */
+
+module.exports = {
+	name: 'debug-info',
+
+	template: [
+		'<div class="carbon-debug">',
+		'  <details class="section carbon-debug__section">',
+		'    <summary class="component component-heading carbon-debug__summary tap-highlight"><h4>Debug</h4></summary>',
+		'    <div class="component component-debug-info carbon-debug__details">',
+		'      <div class="carbon-debug__contents" data-manipulator-target></div>',
+		'      <button type="button" class="carbon-debug__copy">Copy debug info to clipboard</button>',
+		'    </div>',
+		'  </details>',
+		'</div>',
+	].join(''),
+
+	style: [
+		'.carbon-debug h4 { display: inline-block; }',
+		'.carbon-debug code { display: block; font-family: monospace; background: #414141; padding: 4px; }',
+		'.carbon-debug__copy { margin: 1rem 0 0; }'
+	].join(' '),
+
+	manipulator: 'html',
+
+	initialize: function(minified, clayConfig) {
+		if ( ! clayConfig.meta.userData.debugInfo ) {
+			this.hide();
+			return;
+		}
+
+		// The default value is set from the messageKey with a fallback to defaultValue after initialize is called. We hijack defaultValue to display the debug info.
+		this.config.defaultValue =  clayConfig.meta.userData.debugInfo.html || '<p>No cache data yet.</p>';
+
+		// Add click handler for the copy button.
+		var copyButton = this.$element.select('button');
+		console.log(copyButton);
+		copyButton.on('click', function() {
+			console.log(clayConfig.meta.userData.debugInfo.raw);
+			var debugContents = clayConfig.meta.userData.debugInfo.raw;
+			if (debugContents) {
+				// Create temporary textarea to hold the debug contents.
+				var tempTextarea = document.createElement('textarea');
+				tempTextarea.value = debugContents;
+				document.body.appendChild(tempTextarea);
+				tempTextarea.select();
+
+				// Clipboard API is not available outside of secure contexts.
+				var copied = document.execCommand('copy');
+				if (copied) alert('Debug info copied to clipboard.');
+
+				// Clear the selection after copying.
+				document.body.removeChild(tempTextarea);
+			}
+		});
+	},
+};

--- a/src/pkjs/config/debug.js
+++ b/src/pkjs/config/debug.js
@@ -34,34 +34,46 @@ module.exports = {
 	manipulator: 'html',
 
 	initialize: function(minified, clayConfig) {
-		if ( ! clayConfig.meta.userData.debugInfo ) {
+		var debugInfo = clayConfig.meta.userData && clayConfig.meta.userData.debugInfo;
+
+		if (!debugInfo) {
 			this.hide();
 			return;
 		}
 
-		// The default value is set from the messageKey with a fallback to defaultValue after initialize is called. We hijack defaultValue to display the debug info.
-		this.config.defaultValue =  clayConfig.meta.userData.debugInfo.html || '<p>No cache data yet.</p>';
+		function escHtml(s) {
+			return String(s)
+				.replace(/&/g, '&amp;')
+				.replace(/</g, '&lt;')
+				.replace(/>/g, '&gt;');
+		}
 
-		// Add click handler for the copy button.
+		var parts = [];
+		var keys = Object.keys(debugInfo);
+		for (var i = 0; i < keys.length; i++) {
+			var key = keys[i];
+			parts.push(
+				'<details><summary>' + escHtml(key) + '</summary>' +
+				'<code><pre>' + escHtml(JSON.stringify(debugInfo[key], null, 2)) + '</pre></code>' +
+				'</details>'
+			);
+		}
+		this.config.defaultValue = parts.join('');
+
 		var copyButton = this.$element.select('button');
-		console.log(copyButton);
 		copyButton.on('click', function() {
-			console.log(clayConfig.meta.userData.debugInfo.raw);
-			var debugContents = '{"activeWatchInfo":' + JSON.stringify(clayConfig.meta.activeWatchInfo) + ',"cache":' + clayConfig.meta.userData.debugInfo.raw + '}';
-			if (debugContents) {
-				// Create temporary textarea to hold the debug contents.
-				var tempTextarea = document.createElement('textarea');
-				tempTextarea.value = debugContents;
-				document.body.appendChild(tempTextarea);
-				tempTextarea.select();
-
-				// Clipboard API is not available outside of secure contexts.
-				var copied = document.execCommand('copy');
-				if (copied) alert('Debug info copied to clipboard.');
-
-				// Clear the selection after copying.
-				document.body.removeChild(tempTextarea);
+			var allData = { activeWatchInfo: clayConfig.meta.activeWatchInfo };
+			var dkeys = Object.keys(debugInfo);
+			for (var j = 0; j < dkeys.length; j++) {
+				allData[dkeys[j]] = debugInfo[dkeys[j]];
 			}
+			var temp = document.createElement('textarea');
+			temp.value = JSON.stringify(allData);
+			document.body.appendChild(temp);
+			temp.select();
+			var copied = document.execCommand('copy');
+			if (copied) alert('Debug info copied to clipboard.');
+			document.body.removeChild(temp);
 		});
 	},
 };

--- a/src/pkjs/config/debug.js
+++ b/src/pkjs/config/debug.js
@@ -47,7 +47,7 @@ module.exports = {
 		console.log(copyButton);
 		copyButton.on('click', function() {
 			console.log(clayConfig.meta.userData.debugInfo.raw);
-			var debugContents = clayConfig.meta.userData.debugInfo.raw;
+			var debugContents = '{"activeWatchInfo":' + JSON.stringify(clayConfig.meta.activeWatchInfo) + ',"cache":' + clayConfig.meta.userData.debugInfo.raw + '}';
 			if (debugContents) {
 				// Create temporary textarea to hold the debug contents.
 				var tempTextarea = document.createElement('textarea');

--- a/src/pkjs/config/debug.js
+++ b/src/pkjs/config/debug.js
@@ -48,13 +48,19 @@ module.exports = {
 				.replace(/>/g, '&gt;');
 		}
 
+		var allData = { activeWatchInfo: clayConfig.meta.activeWatchInfo };
+		var dkeys = Object.keys(debugInfo);
+		for (var j = 0; j < dkeys.length; j++) {
+			allData[dkeys[j]] = debugInfo[dkeys[j]];
+		}
+
 		var parts = [];
-		var keys = Object.keys(debugInfo);
+		var keys = Object.keys(allData);
 		for (var i = 0; i < keys.length; i++) {
 			var key = keys[i];
 			parts.push(
 				'<details><summary>' + escHtml(key) + '</summary>' +
-				'<code><pre>' + escHtml(JSON.stringify(debugInfo[key], null, 2)) + '</pre></code>' +
+				'<code><pre>' + escHtml(JSON.stringify(allData[key], null, 2)) + '</pre></code>' +
 				'</details>'
 			);
 		}
@@ -62,11 +68,6 @@ module.exports = {
 
 		var copyButton = this.$element.select('button');
 		copyButton.on('click', function() {
-			var allData = { activeWatchInfo: clayConfig.meta.activeWatchInfo };
-			var dkeys = Object.keys(debugInfo);
-			for (var j = 0; j < dkeys.length; j++) {
-				allData[dkeys[j]] = debugInfo[dkeys[j]];
-			}
 			var temp = document.createElement('textarea');
 			temp.value = JSON.stringify(allData);
 			document.body.appendChild(temp);

--- a/src/pkjs/constants.js
+++ b/src/pkjs/constants.js
@@ -1,0 +1,14 @@
+/**
+ * Shared constants for Carbon PebbleKit JS scripts.
+ *
+ * @author    Cory Hughart <cory@coryhughart.com>
+ * @copyright 2026 Cory Hughart
+ * @license   https://www.gnu.org/licenses/gpl-3.0.html GPL-3.0-or-later
+ */
+
+module.exports = {
+	WEATHER_BASE_URL: 'https://api.open-meteo.com/v1/forecast',
+	GEOCODE_BASE_URL: 'https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/reverseGeocode',
+	CACHE_KEY:        'carbon.weather.v3',
+	CACHE_TTL_MS:     15 * 60 * 1000,  // 15 minutes
+};

--- a/src/pkjs/index.js
+++ b/src/pkjs/index.js
@@ -394,39 +394,27 @@ function getWeather() {
 }
 
 /**
- * Format a debug snapshot from the weather cache for the Clay config page.
- * Returns an object with a pre-formatted `html` string.
+ * Build a debug snapshot for the Clay config page.
+ * Returns a plain object whose keys become collapsible sections in the
+ * debug-info component; values are serialised as JSON in the display.
  *
- * @returns {{html: string}}
+ * @returns {{cache: Object|null, settings: Object|null}}
  */
 function formatDebugInfo() {
-	function escHtml(s) {
-		return String(s)
-			.replace(/&/g, '&amp;')
-			.replace(/</g, '&lt;')
-			.replace(/>/g, '&gt;');
+	var result = {};
+	try {
+		var rawCache = localStorage.getItem(CACHE_KEY);
+		result.cache = rawCache ? JSON.parse(rawCache) : null;
+	} catch (e) {
+		result.cache = null;
 	}
 	try {
-		var raw = localStorage.getItem(CACHE_KEY);
-		if (!raw) return { html: '<p>No cache data yet.</p>' };
-		var cache = JSON.parse(raw);
-		var p = cache.payload || {};
-		// Note: toLocaleString() does not seem to be available in this context.
-		var fetched = p.fetch_time
-			? new Date(p.fetch_time * 1000)
-			: 'N/A';
-		var expires = cache.expiresAt
-			? new Date(cache.expiresAt)
-			: 'N/A';
-		var html = [
-			'<p><b>Fetched:</b> '  + fetched + '</p>',
-			'<p><b>Expires:</b> '  + expires + '</p>',
-			'<details><summary>Raw cache</summary><code><pre>' + escHtml(JSON.stringify(p, null, 2)) + '</pre></code></details>'
-		].join('');
-		return { html: html, raw: raw };
+		var rawSettings = localStorage.getItem('clay-settings');
+		result.settings = rawSettings ? JSON.parse(rawSettings) : null;
 	} catch (e) {
-		return { html: `<p>Error reading cache: ${escHtml(e.message)}</p>` };
+		result.settings = null;
 	}
+	return result;
 }
 
 //

--- a/src/pkjs/index.js
+++ b/src/pkjs/index.js
@@ -21,6 +21,8 @@ var {
 	CACHE_TTL_MS,
 } = require('./constants');
 
+var buildInfo = require('../../.buildinfo.json');
+
 var Clay = require('@rebble/clay');
 var clayConfig = require('./config');
 var clay = new Clay(clayConfig, null, { autoHandleEvents: false });
@@ -401,7 +403,9 @@ function getWeather() {
  * @returns {{cache: Object|null, settings: Object|null}}
  */
 function formatDebugInfo() {
-	var result = {};
+	var result = {
+		buildInfo,
+	};
 	try {
 		var rawCache = localStorage.getItem(CACHE_KEY);
 		result.cache = rawCache ? JSON.parse(rawCache) : null;

--- a/src/pkjs/index.js
+++ b/src/pkjs/index.js
@@ -14,14 +14,17 @@
  * @link      https://cr0ybot.com/project/pebble-watchface-carbon
  */
 
-var WEATHER_BASE_URL = 'https://api.open-meteo.com/v1/forecast';
-var GEOCODE_BASE_URL = 'https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/reverseGeocode';
-var CACHE_KEY = 'carbon.weather.v3';
-var CACHE_TTL_MS = 15 * 60 * 1000;  // 15 minutes
+var {
+	WEATHER_BASE_URL,
+	GEOCODE_BASE_URL,
+	CACHE_KEY,
+	CACHE_TTL_MS,
+} = require('./constants');
 
 var Clay = require('@rebble/clay');
 var clayConfig = require('./config');
 var clay = new Clay(clayConfig, null, { autoHandleEvents: false });
+clay.registerComponent(require('./config/debug'));
 
 /**
  * Make a GET request.
@@ -253,6 +256,8 @@ function fetchAndSend(lat, lon) {
 
 	var tempUnit = getTempUnit();
 	payload.temp_unit = tempUnit;
+	payload.lat = lat;
+	payload.lon = lon;
 
 	function tryFinish() {
 		if (!weatherDone || !cityDone) return;
@@ -388,6 +393,42 @@ function getWeather() {
 	);
 }
 
+/**
+ * Format a debug snapshot from the weather cache for the Clay config page.
+ * Returns an object with a pre-formatted `html` string.
+ *
+ * @returns {{html: string}}
+ */
+function formatDebugInfo() {
+	function escHtml(s) {
+		return String(s)
+			.replace(/&/g, '&amp;')
+			.replace(/</g, '&lt;')
+			.replace(/>/g, '&gt;');
+	}
+	try {
+		var raw = localStorage.getItem(CACHE_KEY);
+		if (!raw) return { html: '<p>No cache data yet.</p>' };
+		var cache = JSON.parse(raw);
+		var p = cache.payload || {};
+		// Note: toLocaleString() does not seem to be available in this context.
+		var fetched = p.fetch_time
+			? new Date(p.fetch_time * 1000)
+			: 'N/A';
+		var expires = cache.expiresAt
+			? new Date(cache.expiresAt)
+			: 'N/A';
+		var html = [
+			'<p><b>Fetched:</b> '  + fetched + '</p>',
+			'<p><b>Expires:</b> '  + expires + '</p>',
+			'<details><summary>Raw cache</summary><code><pre>' + escHtml(JSON.stringify(p, null, 2)) + '</pre></code></details>'
+		].join('');
+		return { html: html, raw: raw };
+	} catch (e) {
+		return { html: `<p>Error reading cache: ${escHtml(e.message)}</p>` };
+	}
+}
+
 //
 // Event listeners
 //
@@ -398,6 +439,7 @@ Pebble.addEventListener('ready', function() {
 });
 
 Pebble.addEventListener('showConfiguration', function() {
+	clay.meta.userData.debugInfo = formatDebugInfo();
 	Pebble.openURL(clay.generateUrl());
 });
 

--- a/src/pkjs/index.js
+++ b/src/pkjs/index.js
@@ -400,7 +400,7 @@ function getWeather() {
  * Returns a plain object whose keys become collapsible sections in the
  * debug-info component; values are serialised as JSON in the display.
  *
- * @returns {{cache: Object|null, settings: Object|null}}
+ * @returns {Object}
  */
 function formatDebugInfo() {
 	var result = {

--- a/wscript
+++ b/wscript
@@ -35,17 +35,26 @@ def build(ctx):
 	ctx.load('pebble_sdk')
 
 	# Generate .buildinfo.json from git state and package.json
-	try:
-		git_hash = subprocess.check_output(
-			['git', 'rev-parse', '--short', 'HEAD'],
-			cwd=ctx.path.abspath(),
-			stderr=subprocess.DEVNULL
-		).decode().strip()
-	except Exception:
-		git_hash = 'unknown'
+	def git(*args):
+		try:
+			return subprocess.check_output(
+				['git'] + list(args),
+				cwd=ctx.path.abspath(),
+				stderr=subprocess.DEVNULL
+			).decode().strip()
+		except Exception:
+			return None
+
+	import datetime
 	pkg = json.loads(ctx.path.find_node('package.json').read())
 	ctx.path.make_node('.buildinfo.json').write(
-		json.dumps({ 'version': pkg['version'], 'hash': git_hash }, indent=2) + '\n'
+		json.dumps({
+			'version':   pkg['version'],
+			'hash':      git('rev-parse', '--short', 'HEAD') or 'unknown',
+			'branch':    git('rev-parse', '--abbrev-ref', 'HEAD') or 'unknown',
+			'dirty':     bool(git('status', '--porcelain')),
+			'buildDate': datetime.datetime.now(datetime.timezone.utc).isoformat(),
+		}, indent=2) + '\n'
 	)
 
 	build_worker = os.path.exists('worker_src')

--- a/wscript
+++ b/wscript
@@ -6,6 +6,8 @@
 # set of demo data.
 #
 import os.path
+import json
+import subprocess
 
 top = '.'
 out = 'build'
@@ -31,6 +33,20 @@ def configure(ctx):
 
 def build(ctx):
 	ctx.load('pebble_sdk')
+
+	# Generate .buildinfo.json from git state and package.json
+	try:
+		git_hash = subprocess.check_output(
+			['git', 'rev-parse', '--short', 'HEAD'],
+			cwd=ctx.path.abspath(),
+			stderr=subprocess.DEVNULL
+		).decode().strip()
+	except Exception:
+		git_hash = 'unknown'
+	pkg = json.loads(ctx.path.find_node('package.json').read())
+	ctx.path.make_node('.buildinfo.json').write(
+		json.dumps({ 'version': pkg['version'], 'hash': git_hash }, indent=2) + '\n'
+	)
 
 	build_worker = os.path.exists('worker_src')
 	binaries = []


### PR DESCRIPTION
Adds debug info to the settings page for easier troubleshooting.

It is easy to add new sections by including additional objects in the `formatDebugInfo()` function in PKJS.

Info included in this PR:

- `activeWatchInfo`: directly obtained from Clay
- `buildInfo`: version, commit hash, branch, dirty (uncommitted changes), build date; collected at build time
- `cache`: the current weather data cache object
- `settings`: the current `clay-settings` localStorage object (`null` indicates settings have not been altered)